### PR TITLE
made changes for M2 mac support

### DIFF
--- a/minerva_analysis/server/models/database_model.py
+++ b/minerva_analysis/server/models/database_model.py
@@ -75,4 +75,5 @@ class GatingList(db.Model):
     is_deleted = db.Column(db.Boolean, default=False, nullable=False)
 
 
-db.create_all()
+with app.app_context():
+    db.create_all()

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,29 +1,30 @@
-name: minerva_analysis
+name: gater
 channels:
   - conda-forge
 dependencies:
-  - python=3.7
-  - Flask=1.1.2
-  - jinja2==3.0.3
-  - werkzeug==2.0.3
-  - itsdangerous==2.0.1
   - appdirs
-  - flask-sqlalchemy
+  - flask=2.2.2
+  - flask-sqlalchemy=3.0.2
+  - itsdangerous=2.1.2
+  - jinja2
   - numpy
   - ome-types
   - orjson
   - pandas
-  - pillow=8.1.1
+  - pillow=8.1
+  - pip
+  - pyinstaller
+  - python=3.9.15
   - requests
-  - scikit-learn
   - scikit-image
+  - scikit-learn
   - scipy
   - tifffile=2021.4.8
   - waitress
-  - zarr=2.10.3
-  - pyinstaller
-  - pip
+  - werkzeug=2.2.2
+  - zarr=2.10
+
   - pip:
-      - opencv-python==4.5.3.56
+      - opencv-python==4.7.0.68
 
 


### PR DESCRIPTION
I've updated package versions in `requirements.yml` to use conda packages available to M2 macs.  Because of an update to `flask-sqlalchemy` it also required a one-line change to `minerva_analysis/server/models/database_model.py`.  This is explained in the following link:
https://stackoverflow.com/questions/73961938/flask-sqlalchemy-db-create-all-raises-runtimeerror-working-outside-of-applicat